### PR TITLE
feat: inquiring about and installing ESLint

### DIFF
--- a/packages/ontario-frontend-cli/create/create.js
+++ b/packages/ontario-frontend-cli/create/create.js
@@ -42,19 +42,9 @@ async function createNewProject(answers, options) {
     createDate: new Date().toISOString(),
     projectName: answers.projectName,
     projectDescription: answers.projectDescription,
+    ESLint: answers.ESLint,
   };
 
-  // If the user wants ESLint,
-  // will add the lint script to project's package.json file
-  if (answers.ESLint) {
-    conf.addScripts = conf.addScripts || {};
-    conf.addScripts.lint = `./node_modules/.bin/eslint '**/*.js'`; 
-    // ^ might need to add custom config and change the command here
-    // Where should we look for the config?
-    // eslint will probably by default look in the root directory
-    // might need to add specificity, firstly take from the root directory,
-    // secondly take from --config ./node_modules/eslint-config-ontario/.eslintrc.json
-  }
   // Generate package.json file
   generateNunjucksFile('package.njk', 'package.json', conf);
 
@@ -127,15 +117,6 @@ async function createNewProject(answers, options) {
   );
 
   const npmInstall = spawn('npm', ['install'], { stdio: 'inherit' });
-  // Install ESLint Config only if the user chooses the option
-  // switch the 'placeholder-package' with eslint-config-ontario once live on NPM
-  if (answers.ESLint) {
-    spawn('npm', ['init', '@eslint/config'], { stdio: 'inherit' });
-    spawn('npm', ['install', 'placeholder-package'], { stdio: 'inherit' });
-    console.log(
-      chalk.green('Installing ESLint and eslint-config-ontario package\n')
-    );
-  }
 
   await new Promise((resolve) => {
     npmInstall.on('close', resolve);

--- a/packages/ontario-frontend-cli/create/create.js
+++ b/packages/ontario-frontend-cli/create/create.js
@@ -4,7 +4,7 @@ const { spawn } = require('child_process');
 const inquirer = require('inquirer');
 const nunjucks = require('nunjucks');
 const questions = require('./questions');
-const chalk = require('chalk');
+const colours = require('../utils/chalkColours');
 const figlet = require('figlet');
 
 // Define the __filename and __dirname variables
@@ -25,14 +25,14 @@ async function createNewProject(answers, options) {
 
   // Create the directory for the new project
   console.log(
-    chalk.blueBright(
+    colours.info(
       `\nCreating a new Ontario Frontend project in ${newProjectPath}`,
     ),
   );
   createDirectory(newProjectPath);
 
   // Navigate to the newly created project directory
-  console.log(chalk.blueBright('Navigating to project directory'));
+  console.log(colours.info('Navigating to project directory'));
   process.chdir(newProjectPath);
 
   // Configuration for the new project
@@ -59,21 +59,21 @@ async function createNewProject(answers, options) {
   // Copy config files
   const sourceDir = path.join(__dirname, './skeleton');
   try {
-    console.log(chalk.blueBright('\nCopying config files'));
+    console.log(colours.info('\nCopying config files'));
     fs.cpSync(sourceDir, newProjectPath, {
       recursive: true,
     });
   } catch (error) {
-    console.log(chalk.red(error.message));
+    console.log(colours.error(error.message));
   }
 
   // Generate .eleventy.js file
   generateNunjucksFile('eleventy.njk', `.eleventy.js`, conf);
 
   // Navigate to src directory and generate template files
-  console.log(chalk.blueBright('\nNavigating to src directory'));
+  console.log(colours.info('\nNavigating to src directory'));
   process.chdir('src');
-  console.log(chalk.blueBright('Generating and writing template files'));
+  console.log(colours.info('Generating and writing template files'));
 
   // Generate main English-language page
   generateNunjucksFile('en.njk', `${answers.enRoot}.njk`, conf);
@@ -93,27 +93,27 @@ async function createNewProject(answers, options) {
     '/* Add your script here */',
     (err) => {
       if (err) {
-        console.error(chalk.red(err));
+        console.error(colours.error(err));
       } else {
         console.log(
-          chalk.green('Wrote script.js file at src/assets/js/script.js'),
+          colours.success('Wrote script.js file at src/assets/js/script.js'),
         );
       }
     },
   );
 
   // Navigate to _data directory and generate globals.js file
-  console.log(chalk.blueBright('\nNavigating to _data directory'));
+  console.log(colours.info('\nNavigating to _data directory'));
   process.chdir('_data');
   generateNunjucksFile('globals.njk', 'globals.js', conf);
 
   // Navigate to project directory
-  console.log(chalk.blueBright('\nNavigating to project directory'));
+  console.log(colours.info('\nNavigating to project directory'));
   process.chdir(newProjectPath);
 
   // Install npm dependencies
   console.log(
-    chalk.blueBright('Installing npm dependencies. This may take a minute.'),
+    colours.info('Installing npm dependencies. This may take a minute.'),
   );
 
   const npmInstall = spawn('npm', ['install'], { stdio: 'inherit' });
@@ -128,7 +128,7 @@ async function createNewProject(answers, options) {
     : '@ongov/ontario-frontend';
 
   console.log(
-    chalk.magentaBright(
+    colours.info(
       `\nInstalling core Frontend dependency from ${coreDependencyLocation}`,
     ),
   );
@@ -139,19 +139,19 @@ async function createNewProject(answers, options) {
     ourInstall.on('close', resolve);
   });
 
-  console.log(chalk.green('Npm dependencies installed successfully.'));
+  console.log(colours.success('Npm dependencies installed successfully.'));
 
-  console.log(chalk.green(figlet.textSync('New Project\nCreated!')));
-  console.log(chalk.yellow(`\nProject is now created in ${newProjectPath}`));
-  console.log(chalk.yellow('You can run the project with `npm run serve`'));
-  console.log(chalk.yellow('You can build the project with `npm run build`'));
+  console.log(colours.success(figlet.textSync('New Project\nCreated!')));
+  console.log(colours.info(`\nProject is now created in ${newProjectPath}`));
+  console.log(colours.info('You can run the project with `npm run serve`'));
+  console.log(colours.info('You can build the project with `npm run build`'));
 }
 
 // Function to create a directory
 function createDirectory(path) {
   if (!fs.existsSync(path)) {
     fs.mkdirSync(path, { recursive: true });
-    console.log(chalk.green(`Created directory: ${path}`));
+    console.log(colours.success(`Created directory: ${path}`));
   }
 }
 
@@ -162,9 +162,9 @@ const generateNunjucksFile = (template, fileName, conf) => {
   // Write the rendered content to a file
   try {
     fs.writeFileSync(fileName, content);
-    console.log(chalk.green(`File (${fileName}) written successfully!`));
+    console.log(colours.success(`File (${fileName}) written successfully!`));
   } catch (err) {
-    console.error(chalk.red(err));
+    console.error(colours.error(err));
   }
 };
 

--- a/packages/ontario-frontend-cli/create/create.js
+++ b/packages/ontario-frontend-cli/create/create.js
@@ -44,11 +44,27 @@ async function createNewProject(answers, options) {
     projectDescription: answers.projectDescription,
   };
 
+  // If the user wants ESLint,
+  // will add the lint script to project's package.json file
+  if (answers.ESLint) {
+    conf.addScripts = conf.addScripts || {};
+    conf.addScripts.lint = `./node_modules/.bin/eslint '**/*.js'`; 
+    // ^ might need to add custom config and change the command here
+    // Where should we look for the config?
+    // eslint will probably by default look in the root directory
+    // might need to add specificity, firstly take from the root directory,
+    // secondly take from --config ./node_modules/eslint-config-ontario/.eslintrc.json
+  }
   // Generate package.json file
   generateNunjucksFile('package.njk', 'package.json', conf);
 
   // Generate README.md file
   generateNunjucksFile('README.njk', 'README.md', conf);
+
+  // Generate README.md file
+  if (answers.ESLint) {
+    generateNunjucksFile('eslintrc.njk', '.eslintrc.json', conf);
+  }
 
   // Copy config files
   const sourceDir = path.join(__dirname, './skeleton');
@@ -109,7 +125,18 @@ async function createNewProject(answers, options) {
   console.log(
     chalk.blueBright('Installing npm dependencies. This may take a minute.'),
   );
+
   const npmInstall = spawn('npm', ['install'], { stdio: 'inherit' });
+  // Install ESLint Config only if the user chooses the option
+  // switch the 'placeholder-package' with eslint-config-ontario once live on NPM
+  if (answers.ESLint) {
+    spawn('npm', ['init', '@eslint/config'], { stdio: 'inherit' });
+    spawn('npm', ['install', 'placeholder-package'], { stdio: 'inherit' });
+    console.log(
+      chalk.green('Installing ESLint and eslint-config-ontario package\n')
+    );
+  }
+
   await new Promise((resolve) => {
     npmInstall.on('close', resolve);
   });
@@ -124,11 +151,9 @@ async function createNewProject(answers, options) {
       `\nInstalling core Frontend dependency from ${coreDependencyLocation}`,
     ),
   );
-  const ourInstall = spawn(
-    'npm',
-    ['install', '-S', coreDependencyLocation],
-    { stdio: 'inherit' },
-  );
+  const ourInstall = spawn('npm', ['install', '-S', coreDependencyLocation], {
+    stdio: 'inherit',
+  });
   await new Promise((resolve) => {
     ourInstall.on('close', resolve);
   });

--- a/packages/ontario-frontend-cli/create/questions.js
+++ b/packages/ontario-frontend-cli/create/questions.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 const chalk = require('chalk');
 const figlet = require('figlet');
-const { validFileName, validPath, validYes } = require('../utils/validate-questions');
+const { validFileName, validPath } = require('../utils/validate-questions');
 
 // Print a header for the application in the terminal
 console.log(
@@ -49,11 +49,14 @@ const createQuestions = [
     validate: (value) => validFileName(value),
   },
   {
-    type: 'confirm',
+    type: 'list',
     name: 'ESLint',
-    message: 'Do you want to use ESLint?\nType "y" or "yes" if you want ESLint\n',
-    default: false,
-    validate: (value) => validYes(value)
+    message: 'Want to add ESLint for fixing code problems?',
+    choices: ['Yes', 'No'],
+    default: 'No',
+    filter: function(value) {
+      return value === 'Yes' ? true : false;
+    }
   }
 ];
 

--- a/packages/ontario-frontend-cli/create/questions.js
+++ b/packages/ontario-frontend-cli/create/questions.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 const chalk = require('chalk');
 const figlet = require('figlet');
-const { validFileName, validPath } = require('../utils/validate-questions');
+const { validFileName, validPath, validYes } = require('../utils/validate-questions');
 
 // Print a header for the application in the terminal
 console.log(
@@ -48,6 +48,13 @@ const createQuestions = [
       'What is the file name of the French-language page? (this will also be used for the path: ex. ontario.ca/ma-page-francaise)\n',
     validate: (value) => validFileName(value),
   },
+  {
+    type: 'confirm',
+    name: 'ESLint',
+    message: 'Do you want to use ESLint?\nType "y" or "yes" if you want ESLint\n',
+    default: false,
+    validate: (value) => validYes(value)
+  }
 ];
 
 // Add color to the questions

--- a/packages/ontario-frontend-cli/create/questions.js
+++ b/packages/ontario-frontend-cli/create/questions.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-console */
-const chalk = require('chalk');
+const colours = require('../utils/chalkColours');
 const figlet = require('figlet');
 const { validFileName, validPath } = require('../utils/validate-questions');
 
 // Print a header for the application in the terminal
 console.log(
-  chalk.yellow(
+  colours.banner(
     figlet.textSync('Ontario\nFrontend', { horizontalLayout: 'full' }),
   ),
 );
@@ -62,7 +62,7 @@ const createQuestions = [
 
 // Add color to the questions
 createQuestions.forEach((question) => {
-  question.message = chalk.cyan(question.message);
+  question.message = colours.question(question.message);
 });
 
 // Export the 'createQuestions' array

--- a/packages/ontario-frontend-cli/create/templates/eslintrc.njk
+++ b/packages/ontario-frontend-cli/create/templates/eslintrc.njk
@@ -1,17 +1,6 @@
 {
-    "printWidth": 80,
-    "tabWidth": 2,
-    "semi": true,
-    "singleQuote": true,
-    "trailingComma": "all",
-    "bracketSpacing": true,
-    "bracketSameLine": true,
-    "overrides": [
-      {
-        "files": "*.md",
-        "options": {
-          "singleQuote": false
-        }
-      }
-    ]
+    "extends": "@ongov/eslint-config-ontario-frontend",
+    "rules": {
+        // You can override specific rules or add new ones here
+    }
 }

--- a/packages/ontario-frontend-cli/create/templates/eslintrc.njk
+++ b/packages/ontario-frontend-cli/create/templates/eslintrc.njk
@@ -1,0 +1,17 @@
+{
+    "printWidth": 80,
+    "tabWidth": 2,
+    "semi": true,
+    "singleQuote": true,
+    "trailingComma": "all",
+    "bracketSpacing": true,
+    "bracketSameLine": true,
+    "overrides": [
+      {
+        "files": "*.md",
+        "options": {
+          "singleQuote": false
+        }
+      }
+    ]
+}

--- a/packages/ontario-frontend-cli/create/templates/package.njk
+++ b/packages/ontario-frontend-cli/create/templates/package.njk
@@ -6,12 +6,14 @@
   "scripts": {
     "build": "rm -rf dist && eleventy",
     "debug": "rm -rf dist && DEBUG=* eleventy",
-    "serve": "eleventy --serve",
-    {% for scriptName, scriptValue in addScripts %}"{{ scriptName }}": "{{ scriptValue | safe }}"{% endfor %}
+    "serve": "eleventy --serve"{% if ESLint %},
+    "lint": "./node_modules/.bin/eslint '**/*.js'"{% endif %}
   },
   "author": "TODO changeme",
   "license": "Apache 2.0",
   "devDependencies": {
-    "@11ty/eleventy": "^1.0.1"
+      "@11ty/eleventy": "^1.0.1"{% if ESLint %},
+      "eslint": "latest",
+      "eslint-config-ontario-frontend": "latest"{% endif %}
   }
 }

--- a/packages/ontario-frontend-cli/create/templates/package.njk
+++ b/packages/ontario-frontend-cli/create/templates/package.njk
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "rm -rf dist && eleventy",
     "debug": "rm -rf dist && DEBUG=* eleventy",
-    "serve": "eleventy --serve"
+    "serve": "eleventy --serve",
+    {% for scriptName, scriptValue in addScripts %}"{{ scriptName }}": "{{ scriptValue | safe }}"{% endfor %}
   },
   "author": "TODO changeme",
   "license": "Apache 2.0",

--- a/packages/ontario-frontend-cli/utils/chalkColours.js
+++ b/packages/ontario-frontend-cli/utils/chalkColours.js
@@ -1,0 +1,12 @@
+const chalk = require('chalk');
+
+const colours = {
+  // Define colours using hex codes from the Ontario Design System
+  question: chalk.hex('#FFFFFF'), // Ontario White
+  success: chalk.hex('#DDEDC7'), // Ontario Light Green
+  error: chalk.hex('#CD0000'), // Ontario Alert Red
+  banner: chalk.hex('#C5EEFA'), // Ontario Light Sky
+  info: chalk.hex('#F1E3F2'), // Ontario Light Purple
+};
+
+module.exports = colours;

--- a/packages/ontario-frontend-cli/utils/validate-questions.js
+++ b/packages/ontario-frontend-cli/utils/validate-questions.js
@@ -28,18 +28,7 @@ const validPath = (value) => {
   }
 };
 
-// Validate questions such as (install ESLint?)
-// The function checks if the input is "yes", only then will ESLint be installed
-// leaving the input empty or enterting any other value will resort to the default false value
-const validYes = (value) => {
-  value = value.trim().toLowerCase();
-  if (value === 'yes' || value === 'y') {
-    return true;
-  }
-}
-
 module.exports = {
   validFileName,
-  validPath,
-  validYes
+  validPath
 };

--- a/packages/ontario-frontend-cli/utils/validate-questions.js
+++ b/packages/ontario-frontend-cli/utils/validate-questions.js
@@ -3,20 +3,20 @@ const fs = require('fs');
 // Validate the file name
 // The function checks if the input is present, lowercase, URL-safe, and does not begin with a dot or an underscore
 const validFileName = (value) => {
-  if (!value || value.trim() === "") {
-    return "Please enter a value";
+  if (!value || value.trim() === '') {
+    return 'Please enter a value';
   }
   if (value !== value.toLowerCase()) {
-    return "Value must be lowercase";
+    return 'Value must be lowercase';
   }
   if (!/^[\w-]+$/.test(value)) {
-    return "Value must be URL-safe (only letters, numbers, - and _ allowed)";
+    return 'Value must be URL-safe (only letters, numbers, - and _ allowed)';
   }
   if (/^[._]/.test(value)) {
-    return "Value cannot begin with a dot or an underscore";
+    return 'Value cannot begin with a dot or an underscore';
   }
   return true;
-}
+};
 
 // Validate the path
 // The function checks if the path exists
@@ -24,11 +24,22 @@ const validPath = (value) => {
   if (fs.existsSync(value)) {
     return true;
   } else {
-    return "The provided path does not exist. Please enter a valid path.";
+    return 'The provided path does not exist. Please enter a valid path.';
+  }
+};
+
+// Validate questions such as (install ESLint?)
+// The function checks if the input is "yes", only then will ESLint be installed
+// leaving the input empty or enterting any other value will resort to the default false value
+const validYes = (value) => {
+  value = value.trim().toLowerCase();
+  if (value === 'yes' || value === 'y') {
+    return true;
   }
 }
 
 module.exports = {
   validFileName,
   validPath,
+  validYes
 };


### PR DESCRIPTION
  ### Acceptance Criteria and Response
When setting up a new project via the interactive CLI script, users are prompted to specify if they want to use ESLint in their project,
The default response for the ESLint prompt is “No”: 
- [x] - Users are inquired to install ESLint
- [x] - If not, the answer defaults to **no**

When a user opts to add ESLint to their project, the most current stable version of ESLint is added as a project dependency,
When a user opts to add ESLint to their project, eslint-config-ontario-frontend is added as a project dependency,
When a user opts to add ESLint to their project, eslint and eslint-config-ontario-frontend are installed during the project setup process alongside other project dependencies:

- [x] - Adding ESLint dependency and init to the project
- [x] - Also adding the `eslint-config-ontario-frontend` npm installation, currently with the placeholder package name: `"placeholder-package"` – will switch to the actual package name once its live on NPM.

    
When a user opts to add ESLint to their project, an eslint.config.js file is added to the project and extends the eslint-config-ontario-frontend configuration:

- [x]  - Adding the config file `.eslintrc.json` to the project's root directory.
- [ ]  - *Question: if the user already gets the config file in their root directory, why would they need to install our config package? And if we want to have two configs, do you want me to add specificity where the user's root config takes precedence over our eslint package config? 