### PR TITLE
refactor: removed the project location prompt

### DIFF
--- a/packages/ontario-frontend-cli/create/create.js
+++ b/packages/ontario-frontend-cli/create/create.js
@@ -21,7 +21,7 @@ nunjucks.configure(TEMPLATE_DIR);
 async function createNewProject(answers, options) {
   // Store some user answers necessary for the subsequent steps
   const projectName = answers.projectName;
-  const newProjectPath = path.resolve(answers.destination, projectName);
+  const newProjectPath = path.resolve(process.cwd(), projectName);
 
   // Create the directory for the new project
   console.log(

--- a/packages/ontario-frontend-cli/create/questions.js
+++ b/packages/ontario-frontend-cli/create/questions.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 const colours = require('../utils/chalkColours');
 const figlet = require('figlet');
-const { validFileName, validPath } = require('../utils/validate-questions');
+const { validFileName } = require('../utils/validate-questions');
 
 // Print a header for the application in the terminal
 console.log(
@@ -25,14 +25,6 @@ const createQuestions = [
     name: 'projectDescription',
     message: 'Specify a short description for your project:\n',
     default: 'New Ontario Frontend project',
-  },
-  {
-    type: 'input',
-    name: 'destination',
-    message:
-      'Specify an alternative location to create your project (or press enter to use the current directory):\n',
-    default: process.cwd(),
-    validate: (value) => validPath(value),
   },
   {
     type: 'input',

--- a/packages/ontario-frontend-cli/utils/validate-questions.js
+++ b/packages/ontario-frontend-cli/utils/validate-questions.js
@@ -18,17 +18,6 @@ const validFileName = (value) => {
   return true;
 };
 
-// Validate the path
-// The function checks if the path exists
-const validPath = (value) => {
-  if (fs.existsSync(value)) {
-    return true;
-  } else {
-    return 'The provided path does not exist. Please enter a valid path.';
-  }
-};
-
 module.exports = {
-  validFileName,
-  validPath
+  validFileName
 };


### PR DESCRIPTION
### Acceptance Criteria & Response

- The CLI tool no longer provides users an option to initialize a project in a directory other than the one they are currently in.
- When a user uses the CLI tool to set up a new project, the process proceeds with the project setup without requiring explicit confirmation of the directory.
- When a user uses the CLI tool to set up a new project, the new project is initialized in the current working directory without checking if it is empty.
- Existing functionality of the CLI tool, unrelated to the project directory prompt, remains unaffected by the removal of this prompt.

- [x] - The location prompt has been removed
- [x] - The project gets installed in the current working directory
- [x] - all the extra linked code to the location question has been removed 