### PR TITLE
refactor: removed the project description prompt

### DIFF
--- a/packages/ontario-frontend-cli/create/create.js
+++ b/packages/ontario-frontend-cli/create/create.js
@@ -41,7 +41,6 @@ async function createNewProject(answers, options) {
     frenchRoot: answers.frRoot,
     createDate: new Date().toISOString(),
     projectName: answers.projectName,
-    projectDescription: answers.projectDescription,
     ESLint: answers.ESLint,
   };
 

--- a/packages/ontario-frontend-cli/create/questions.js
+++ b/packages/ontario-frontend-cli/create/questions.js
@@ -22,12 +22,6 @@ const createQuestions = [
   },
   {
     type: 'input',
-    name: 'projectDescription',
-    message: 'Specify a short description for your project:\n',
-    default: 'New Ontario Frontend project',
-  },
-  {
-    type: 'input',
     name: 'destination',
     message:
       'Specify an alternative location to create your project (or press enter to use the current directory):\n',

--- a/packages/ontario-frontend-cli/create/templates/README.njk
+++ b/packages/ontario-frontend-cli/create/templates/README.njk
@@ -4,7 +4,7 @@ Built with the [Ontario Frontend toolkit](https://github.com/ongov/ontario-front
 
 ## Project Description
 
-Ontario Frontend Project (Add your project description).
+Ontario Frontend Project (TODO: Replace with a description of your project).
 
 ## About this README.md file
 

--- a/packages/ontario-frontend-cli/create/templates/README.njk
+++ b/packages/ontario-frontend-cli/create/templates/README.njk
@@ -4,7 +4,7 @@ Built with the [Ontario Frontend toolkit](https://github.com/ongov/ontario-front
 
 ## Project Description
 
-{{ projectDescription }}
+Ontario Frontend Project (Add your project description).
 
 ## About this README.md file
 

--- a/packages/ontario-frontend-cli/create/templates/package.njk
+++ b/packages/ontario-frontend-cli/create/templates/package.njk
@@ -1,7 +1,7 @@
 {
   "name": "{{ projectName }}",
   "version": "0.0.1",
-  "description": "Ontario Frontend Project (Add your project description here)",
+  "description": "Ontario Frontend Project (TODO: Replace with a description of your project)",
   "main": "index.js",
   "scripts": {
     "build": "rm -rf dist && eleventy",

--- a/packages/ontario-frontend-cli/create/templates/package.njk
+++ b/packages/ontario-frontend-cli/create/templates/package.njk
@@ -1,7 +1,7 @@
 {
   "name": "{{ projectName }}",
   "version": "0.0.1",
-  "description": "{{ projectDescription }}",
+  "description": "Ontario Frontend Project (Add your project description here)",
   "main": "index.js",
   "scripts": {
     "build": "rm -rf dist && eleventy",


### PR DESCRIPTION
### Acceptance criteria & Response

- The CLI tool no longer prompts users to provide a short description during the interactive project setup process.
- The description field in the project’s package.json file is no longer automatically populated during the interactive project setup process.
- Running the interactive project setup without providing a project description does not result in any errors or issues during project initialization.
 - Existing functionality of the CLI tool, unrelated to the project description prompt, remains unaffected by the removal of this prompt.

- [x] - The **project description** prompt has been removed
- [x] - The project description (in `package.json` and `README.md`) have a placeholder instead which the user can change `"Ontario Frontend Project (Add your project description here)"`
- [x] - all the extra linked code to the project description question has been removed 
