### PR TITLE
ONFRONT-24 Add CLI parameters for bypassing English and French page names

### DIFF
--- a/packages/ontario-frontend-cli/bin/ontario-create-app.js
+++ b/packages/ontario-frontend-cli/bin/ontario-create-app.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 const Command = require('commander').Command;
-const { handleCreateAppCommand } = require('../commands/ontario-create-app/handleCreateApp');
+const {
+  handleCreateAppCommand,
+} = require('../commands/ontario-create-app/handleCreateApp');
 const { ROOT_DIR } = require('../core/config');
 const { readPackageJson } = require('../core/utils');
 const logger = require('../core/utils/logger');
@@ -10,77 +12,99 @@ const program = new Command();
 
 /**
  * readPackageJson() is an async function that is used to read the contents of the package.json file.
- * 
- * These contents are checked against in several places in the below code, therefore the all of the 
+ *
+ * These contents are checked against in several places in the below code, therefore the all of the
  * program commands should be wrapped in a self-executing async function.
- * 
+ *
  * Without this async wrapper function, the program will exit unexpectedly after user input.
- */ 
-(
-  async () => {
-    const packageJson = await readPackageJson(ROOT_DIR);
+ */
+(async () => {
+  const packageJson = await readPackageJson(ROOT_DIR);
 
-    program
-      .name('ontario-create-app')
-      .version(packageJson.version, '-v, --version', 'Output the current version')
-      .description('Create a new Ontario Frontend project')
-      .option(
-        '--projectName <name>',
-        'Specify the project name (lowercase, hyphens, underscores allowed)',
-        (value) => {
-          // Leverage the validation used with Commander for prompted questions
-          // The validation result is either True if the value is valid, or
-          // it is a string representing the error and remedy
-          const validationResult = validFileName(value);
-          if (validationResult !== true) {
-            logger.error('Invalid project name - ',validationResult);
-            process.exit(1);
-          }
-          logger.info('Using project name: ', value);
-          return value;
-        }
-      )
-      .option(
-        '--debug', 'Enable debug output'
-      )
-      .option(
-        '--local',
-        'Use a local version of the Ontario Frontend core dependency',
-      )
-      .action(async (cmd) => {
-        logger.setDebug(cmd.debug);
-        logger.debug('CLI options:', cmd);
-
-        try {
-          await handleCreateAppCommand(cmd);
-        } catch (error) {
-          logger.error(`Error creating project: ${error.message}`);
+  program
+    .name('ontario-create-app')
+    .version(packageJson.version, '-v, --version', 'Output the current version')
+    .description('Create a new Ontario Frontend project')
+    .option(
+      '--projectName <name>',
+      'Specify the project name (lowercase, hyphens, underscores allowed)',
+      (value) => {
+        // Leverage the validation used with Commander for prompted questions
+        // The validation result is either True if the value is valid, or
+        // it is a string representing the error and remedy
+        const validationResult = validFileName(value);
+        if (validationResult !== true) {
+          logger.error('Invalid project name - ', validationResult);
           process.exit(1);
         }
-      });
+        logger.info('Using project name: ', value);
+        return value;
+      },
+    )
+    .option(
+      '--enPage <name>',
+      'Specify the English page name (alphanumeric, hyphens, underscores allowed)',
+      (value) => {
+        const validationResult = validFileName(value);
+        if (validationResult !== true) {
+          logger.error('Invalid enPage name - ', validationResult);
+          process.exit(1);
+        }
+        logger.info('Using English page name: ', value);
+        return value;
+      },
+    )
+    .option(
+      '--frPage <name>',
+      'Specify the French page name (alphanumeric, hyphens, underscores allowed)',
+      (value) => {
+        const validationResult = validFileName(value);
+        if (validationResult !== true) {
+          logger.error('Invalid French page name - ', validationResult);
+          process.exit(1);
+        }
+        logger.info('Using French page name: ', value);
+        return value;
+      },
+    )
+    .option('--debug', 'Enable debug output')
+    .option(
+      '--local',
+      'Use a local version of the Ontario Frontend core dependency',
+    )
+    .action(async (cmd) => {
+      logger.setDebug(cmd.debug);
+      logger.debug('CLI options:', cmd);
 
-    // Error on unknown commands should not interfere with the help option
-    program.on('command:*', (operands) => {
-      console.error(
-        `Invalid command: ${operands[0]}\nSee --help for a list of available commands.`,
-      );
-      process.exit(1);
+      try {
+        await handleCreateAppCommand(cmd);
+      } catch (error) {
+        logger.error(`Error creating project: ${error.message}`);
+        process.exit(1);
+      }
     });
 
-    // Append custom help text with a link to the developer site
-    program.addHelpText(
-      'after',
-      `\nFor more information, visit our developer site at https://developer.ontario.ca`,
+  // Error on unknown commands should not interfere with the help option
+  program.on('command:*', (operands) => {
+    console.error(
+      `Invalid command: ${operands[0]}\nSee --help for a list of available commands.`,
     );
+    process.exit(1);
+  });
 
-    // Ensure the help information is displayed when the user explicitly asks for it
-    program
-      .command('help')
-      .description('Display help information and resources')
-      .action(() => {
-        program.help();
-      });
+  // Append custom help text with a link to the developer site
+  program.addHelpText(
+    'after',
+    `\nFor more information, visit our developer site at https://developer.ontario.ca`,
+  );
 
-    program.parse(process.argv);
-  }
-)();
+  // Ensure the help information is displayed when the user explicitly asks for it
+  program
+    .command('help')
+    .description('Display help information and resources')
+    .action(() => {
+      program.help();
+    });
+
+  program.parse(process.argv);
+})();

--- a/packages/ontario-frontend-cli/bin/ontario-create-app.js
+++ b/packages/ontario-frontend-cli/bin/ontario-create-app.js
@@ -27,7 +27,7 @@ const program = new Command();
     .description('Create a new Ontario Frontend project')
     .option(
       '--projectName <name>',
-      'Specify the project name (lowercase, hyphens, underscores allowed)',
+      'Specify the project name (lowercase, alphanumeric, hyphens, underscores allowed)',
       (value) => {
         // Leverage the validation used with Commander for prompted questions
         // The validation result is either True if the value is valid, or
@@ -43,7 +43,7 @@ const program = new Command();
     )
     .option(
       '--enPage <name>',
-      'Specify the English page name (alphanumeric, hyphens, underscores allowed)',
+      'Specify the English page name (lowercase, alphanumeric, hyphens, underscores allowed)',
       (value) => {
         const validationResult = validFileName(value);
         if (validationResult !== true) {
@@ -56,7 +56,7 @@ const program = new Command();
     )
     .option(
       '--frPage <name>',
-      'Specify the French page name (alphanumeric, hyphens, underscores allowed)',
+      'Specify the French page name (lowercase, alphanumeric, hyphens, underscores allowed)',
       (value) => {
         const validationResult = validFileName(value);
         if (validationResult !== true) {

--- a/packages/ontario-frontend-cli/commands/ontario-create-app/handleCreateApp.js
+++ b/packages/ontario-frontend-cli/commands/ontario-create-app/handleCreateApp.js
@@ -84,6 +84,7 @@ async function generateProjectFiles(newProjectPath, conf) {
   logger.debug('Configuration for project files:', conf);
 
   const templates = ontarioCreateAppTemplates(conf);
+  logger.debug('ontarioCreateAppTemplates(conf): ', templates);
   for (let { template, outputDir, outputFile } of templates) {
     const outputPath = path.join(newProjectPath, outputDir, outputFile);
     const directoryPath = path.dirname(outputPath); // Get the directory path for the current file
@@ -93,6 +94,7 @@ async function generateProjectFiles(newProjectPath, conf) {
 
     try {
       logger.info(`Generating ${template}`);
+      logger.debug(`Rendering ${template} and writing to ${outputPath}`);
       await renderAndWrite(
         path.join(CREATE_TEMPLATE_DIR, template),
         outputPath,

--- a/packages/ontario-frontend-cli/commands/ontario-create-app/handleCreateApp.js
+++ b/packages/ontario-frontend-cli/commands/ontario-create-app/handleCreateApp.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const inquirer = require('inquirer');
-
 const {
   ensureDirectory,
   copy,
@@ -19,11 +18,15 @@ const {
   CREATE_BOILERPLATE_DIR,
   LOCAL_CORE_DEPENDENCY_DIR,
 } = require('../../core/config');
-
 const { createOntarioAppQuestions } = require('../../core/questions');
 
 configureTemplates(CREATE_TEMPLATE_DIR);
 
+/**
+ * Function to create a new Ontario Frontend project.
+ * @param {Object} answers - The answers provided by the user.
+ * @param {Object} options - Additional options for project creation.
+ */
 async function createNewProject(answers, options) {
   logger.debug('Answers received:', answers);
   logger.debug('Options received:', options);
@@ -43,7 +46,7 @@ async function createNewProject(answers, options) {
 
   // Configuration for the new project
   const conf = {
-    ...answers, //Directly spread relevant answers
+    ...answers,
     createDate: new Date().toISOString(),
     ontarioFrontendDependency: ontarioFrontendDependency,
   };
@@ -52,35 +55,15 @@ async function createNewProject(answers, options) {
 
   logger.success('Created project context');
 
-  // Copy boilerplate files
+  // Perform steps to set up the project
   await copyBoilerplateFiles(newProjectPath);
   logger.debug('Boilerplate files copied successfully');
 
-  // Generate project files
   await generateProjectFiles(newProjectPath, conf);
   logger.debug('Project files generated successfully');
 
-  // Copy ESLint config if opted-in
-  if (conf.addESLint) {
-    try {
-      await handlePackageCopy(newProjectPath, 'eslint');
-
-      logger.debug('ESLint configuration copied successfully');
-    } catch (err) {
-      throw new Error(`Failed to copy ESLint configuration: ${err.message}`);
-    }
-  }
-
-  // Copy Prettier config if opted-in
-  if (conf.addPrettier) {
-    try {
-      await handlePackageCopy(newProjectPath, 'prettier');
-
-      logger.debug('Prettier configuration copied successfully');
-    } catch (err) {
-      throw new Error(`Failed to copy Prettier configuration: ${err.message}`);
-    }
-  }
+  // Copy ESLint and Prettier configurations if opted-in
+  await copyOptionalConfig(newProjectPath, conf);
 
   // Install npm dependencies, including the core Frontend dependency
   await installAllPackages(newProjectPath);
@@ -91,6 +74,11 @@ async function createNewProject(answers, options) {
   logger.info('You can build the project with `npm run build`');
 }
 
+/**
+ * Function to generate project files.
+ * @param {string} newProjectPath - The path to the new project directory.
+ * @param {Object} conf - The configuration object for the project.
+ */
 async function generateProjectFiles(newProjectPath, conf) {
   logger.info('Generating project files');
   logger.debug('Configuration for project files:', conf);
@@ -115,28 +103,51 @@ async function generateProjectFiles(newProjectPath, conf) {
       logger.error(
         `Failed to render and write ${outputPath}: ${error.message}`,
       );
-      // Throw the error to halt the execution if one file fails to generate
       throw error;
     }
   }
   logger.success('Generated project files');
 }
 
+/**
+ * Function to copy boilerplate files.
+ * @param {string} newProjectPath - The path to the new project directory.
+ */
 async function copyBoilerplateFiles(newProjectPath) {
   logger.info('Copying boilerplate files');
   copy(CREATE_BOILERPLATE_DIR, newProjectPath);
   logger.success('Project boilerplate files copied successfully.');
 }
 
+/**
+ * Function to copy optional ESLint and Prettier configurations.
+ * @param {string} newProjectPath - The path to the new project directory.
+ * @param {Object} conf - The configuration object for the project.
+ */
+async function copyOptionalConfig(newProjectPath, conf) {
+  if (conf.addESLint) {
+    await safelyCopyPackage(newProjectPath, 'eslint');
+  }
+  if (conf.addPrettier) {
+    await safelyCopyPackage(newProjectPath, 'prettier');
+  }
+}
+
+/**
+ * Command handler for creating a new Ontario Frontend project.
+ * @param {Object} cmd - The command object containing user inputs and options.
+ */
 async function handleCreateAppCommand(cmd = {}) {
   // Enable debug logging if --debug option is set
   logger.setDebug(cmd.debug);
-  
+
   try {
     // Extract options from the command
     const options = {
       isLocal: cmd.local || false, // Check if the user indicated they want to use a local version of the toolkit
       projectName: cmd.projectName || '',
+      enPage: cmd.enPage || '',
+      frPage: cmd.frPage || '',
     };
 
     logger.debug('Command options:', options);
@@ -144,18 +155,26 @@ async function handleCreateAppCommand(cmd = {}) {
     // Print a header for the application in the terminal
     console.log(textStyling.banner('Ontario\nFrontend'));
 
-    // If projectName is provided, skip the project name question
-    // Otherwise, prompt the user with all questions
-    const answers = await inquirer.prompt(
-      createOntarioAppQuestions(!options.projectName),
-    );
+    // Determine which questions to ask based on options passed to command
+    const askQuestions = {
+      askProjectName: !options.projectName,
+      askEnPage: !options.enPage,
+      askFrPage: !options.frPage,
+    };
+
+    const questions = createOntarioAppQuestions(askQuestions);
+
+    const answers = await inquirer.prompt(questions);
 
     logger.debug('User answers:', answers);
 
-    // Merge the answers with the provided projectName, if any
-    const finalAnswers = options.projectName
-      ? { ...answers, projectName: options.projectName }
-      : answers;
+    // Merge the answers with the provided projectName, enPage, and frPage if any
+    const finalAnswers = {
+      ...answers,
+      projectName: options.projectName || answers.projectName,
+      enPage: options.enPage || answers.enPage,
+      frPage: options.frPage || answers.frPage,
+    };
 
     logger.debug('Final answers:', finalAnswers);
 

--- a/packages/ontario-frontend-cli/commands/ontario-create-app/handleCreateApp.js
+++ b/packages/ontario-frontend-cli/commands/ontario-create-app/handleCreateApp.js
@@ -126,10 +126,10 @@ async function copyBoilerplateFiles(newProjectPath) {
  */
 async function copyOptionalConfig(newProjectPath, conf) {
   if (conf.addESLint) {
-    await safelyCopyPackage(newProjectPath, 'eslint');
+    await handlePackageCopy(newProjectPath, 'eslint');
   }
   if (conf.addPrettier) {
-    await safelyCopyPackage(newProjectPath, 'prettier');
+    await handlePackageCopy(newProjectPath, 'prettier');
   }
 }
 

--- a/packages/ontario-frontend-cli/core/operations/file/copy.js
+++ b/packages/ontario-frontend-cli/core/operations/file/copy.js
@@ -1,15 +1,33 @@
 const fs = require('fs');
-const logger = require('../../utils/logger');
+const logger = require('../logger');
 
+/**
+ * Copies files and directories from the source path to the destination path.
+ *
+ * @param {string} source - The path to the source files or directory.
+ * @param {string} destination - The path to the destination directory.
+ * @throws Will throw an error if the copy operation fails.
+ */
 function copy(source, destination) {
-    try {
-        fs.cpSync(source, destination, { recursive: true });
-        logger.info(`Copied from ${source} to ${destination}`);
-    } catch (error) {
-        logger.error(`Error copying files: ${error.message}`);
-        // Rethrow
-        throw error;
-    }
+  try {
+    fs.cpSync(source, destination, { recursive: true });
+    logger.info(`Copied from ${source} to ${destination}`);
+  } catch (error) {
+    logger.error(`Error copying from ${source} to ${destination}: ${error.message}`);
+    throw error; // Rethrow the error to be handled by the calling function
+  }
 }
 
-module.exports = { copy };
+/**
+ * Copies files from a list of source paths to their corresponding destination paths.
+ *
+ * @param {Array<{source: string, destination: string}>} files - The list of files to copy.
+ * @throws Will throw an error if any copy operation fails.
+ */
+function copyFiles(files) {
+  for (const { source, destination } of files) {
+    copy(source, destination);
+  }
+}
+
+module.exports = { copy, copyFiles };

--- a/packages/ontario-frontend-cli/core/operations/file/copy.js
+++ b/packages/ontario-frontend-cli/core/operations/file/copy.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const logger = require('../logger');
+const logger = require('../../utils/logger');
 
 /**
  * Copies files and directories from the source path to the destination path.

--- a/packages/ontario-frontend-cli/core/questions/index.js
+++ b/packages/ontario-frontend-cli/core/questions/index.js
@@ -3,9 +3,21 @@ const languagePageQuestions = require('./languagePageQuestions');
 const eslintQuestion = require('./eslintQuestion');
 const prettierQuestion = require('./prettierQuestion');
 
-const createOntarioAppQuestions = (askProjectName) => [
-  projectNameQuestion(askProjectName),
-  ...languagePageQuestions,
+/**
+ * Generates the list of questions to be asked during the project creation process.
+ *
+ * @param {Object} askQuestions - An object that determines which questions to ask.
+ * @param {boolean} askQuestions.askProjectName - Whether to ask for the project name.
+ * @param {boolean} askQuestions.askEnPage - Whether to ask for the English page name.
+ * @param {boolean} askQuestions.askFrPage - Whether to ask for the French page name.
+ * @returns {Array<Object>} An array of question objects to be used with inquirer.prompt.
+ *
+ * The function conditionally includes questions based on the provided `askQuestions` object.
+ * Each question is imported from a separate module to keep the code modular and maintainable.
+ */
+const createOntarioAppQuestions = (askQuestions) => [
+  projectNameQuestion(askQuestions.askProjectName),
+  ...languagePageQuestions(askQuestions.askEnPage, askQuestions.askFrPage),
   eslintQuestion,
   prettierQuestion,
 ];

--- a/packages/ontario-frontend-cli/core/questions/languagePageQuestions.js
+++ b/packages/ontario-frontend-cli/core/questions/languagePageQuestions.js
@@ -1,19 +1,28 @@
 const { validFileName } = require('../validation');
 const { question } = require('../utils/styling/textStyling');
 
-const languagePageQuestions = [
+/**
+ * Generates an array of question objects for the English and French page names.
+ *
+ * @param {boolean} askEnPage - Whether to ask for the English page name.
+ * @param {boolean} askFrPage - Whether to ask for the French page name.
+ * @returns {Array<Object>} An array of question objects to be used with inquirer.prompt.
+ */
+const languagePageQuestions = (askEnPage, askFrPage) => [
   {
     type: 'input',
     name: 'enRoot',
-    message: question('English-language page name (for URL path):\n'),
+    message: question('English-language page name (for URL path; lowercase, hyphens, underscores allowed):\n'),
     validate: validFileName,
+    when: askEnPage,
   },
   {
     type: 'input',
     name: 'frRoot',
-    message: question('French-language page name (for URL path):\n'),
+    message: question('French-language page name (for URL path; lowercase, hyphens, underscores allowed):\n'),
     validate: validFileName,
-  }
+    when: askFrPage,
+  },
 ];
 
 module.exports = languagePageQuestions;

--- a/packages/ontario-frontend-cli/core/questions/languagePageQuestions.js
+++ b/packages/ontario-frontend-cli/core/questions/languagePageQuestions.js
@@ -12,14 +12,14 @@ const languagePageQuestions = (askEnPage, askFrPage) => [
   {
     type: 'input',
     name: 'enPage',
-    message: question('English-language page name (for URL path; lowercase, hyphens, underscores allowed):\n'),
+    message: question('English-language page name (for URL path; lowercase, alphanumeric, hyphens, underscores allowed):\n'),
     validate: validFileName,
     when: askEnPage,
   },
   {
     type: 'input',
     name: 'frPage',
-    message: question('French-language page name (for URL path; lowercase, hyphens, underscores allowed):\n'),
+    message: question('French-language page name (for URL path; lowercase, alphanumeric, hyphens, underscores allowed):\n'),
     validate: validFileName,
     when: askFrPage,
   },

--- a/packages/ontario-frontend-cli/core/questions/languagePageQuestions.js
+++ b/packages/ontario-frontend-cli/core/questions/languagePageQuestions.js
@@ -11,14 +11,14 @@ const { question } = require('../utils/styling/textStyling');
 const languagePageQuestions = (askEnPage, askFrPage) => [
   {
     type: 'input',
-    name: 'enRoot',
+    name: 'enPage',
     message: question('English-language page name (for URL path; lowercase, hyphens, underscores allowed):\n'),
     validate: validFileName,
     when: askEnPage,
   },
   {
     type: 'input',
-    name: 'frRoot',
+    name: 'frPage',
     message: question('French-language page name (for URL path; lowercase, hyphens, underscores allowed):\n'),
     validate: validFileName,
     when: askFrPage,

--- a/packages/ontario-frontend-cli/core/questions/projectNameQuestion.js
+++ b/packages/ontario-frontend-cli/core/questions/projectNameQuestion.js
@@ -1,10 +1,18 @@
 const { validFileName } = require('../validation');
 const { question } = require('../utils/styling/textStyling');
 
+/**
+ * Generates a question object for the project name.
+ *
+ * @param {boolean} askProjectName - Whether to ask for the project name.
+ * @returns {Object} A question object to be used with inquirer.prompt.
+ */
 const projectNameQuestion = (askProjectName) => ({
   type: 'input',
   name: 'projectName',
-  message: question('Project name (lowercase, hyphens, underscores allowed):\n'),
+  message: question(
+    'Project name (lowercase, hyphens, underscores allowed):\n',
+  ),
   default: 'my-frontend-project',
   filter: (input) => input.trim().toLowerCase(), // Normalize input
   validate: validFileName,

--- a/packages/ontario-frontend-cli/core/questions/projectNameQuestion.js
+++ b/packages/ontario-frontend-cli/core/questions/projectNameQuestion.js
@@ -11,7 +11,7 @@ const projectNameQuestion = (askProjectName) => ({
   type: 'input',
   name: 'projectName',
   message: question(
-    'Project name (lowercase, hyphens, underscores allowed):\n',
+    'Project name (lowercase, alphanumeric, hyphens, underscores allowed):\n',
   ),
   default: 'my-frontend-project',
   filter: (input) => input.trim().toLowerCase(), // Normalize input

--- a/packages/ontario-frontend-cli/core/utils/process/copyPackage.js
+++ b/packages/ontario-frontend-cli/core/utils/process/copyPackage.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const logger = require('../logger');
 const { SHARED_BOILERPLATE_DIR, PACKAGES_CONFIG } = require('../../config');
-const { copyFiles } = require('../operations/copy');
+const { copyFiles } = require('../../operations/file/copy');
 
 /**
  * Copies package configuration files from the shared directory to the specified output path.

--- a/packages/ontario-frontend-cli/core/utils/process/copyPackage.js
+++ b/packages/ontario-frontend-cli/core/utils/process/copyPackage.js
@@ -1,35 +1,38 @@
 const path = require('path');
-
 const logger = require('../logger');
 const { SHARED_BOILERPLATE_DIR, PACKAGES_CONFIG } = require('../../config');
-const { copy } = require('../../operations');
+const { copyFiles } = require('../operations/copy');
 
 /**
- * Copy package configuration files from the 
- * resources/boilerplate/shared directory to one that is specified.
+ * Copies package configuration files from the shared directory to the specified output path.
  *
  * @async
- * 
- * @param {string} outputPath - The path inside your project that you wish to execute the copy into.
- * @param {string} packageName - The name of the package you wish to copy config for (e.g. eslint, prettier).
- * 
- * @example
- * // In the current directory, copy the .eslintrc.js file from the shared directory.
- * await handlePackageCopy(path.resolve(process.cwd()), 'eslint');
- */ 
+ * @param {string} outputPath - The path inside your project where the files should be copied.
+ * @param {string} packageName - The name of the package you wish to copy config for (e.g., eslint, prettier).
+ * @throws Will throw an error if the package configuration is not found or any copy operation fails.
+ */
 async function handlePackageCopy(outputPath, packageName) {
-  const packageFiles = PACKAGES_CONFIG[packageName]?.configFiles; // Get our packageFiles from the config
-  
-  if ( !Array.isArray(packageFiles) ) {
-    // This condition fails as expected BUT this error is not getting propogated
-    throw new Error(`Package configuration for ${packageName} not found.`);
-  }
+  try {
+    const packageFiles = PACKAGES_CONFIG[packageName]?.configFiles;
 
-  for (const file of packageFiles) {
-    const fullPackagePath = path.join(SHARED_BOILERPLATE_DIR, file.source);
-    const fullOutputPath = path.join(outputPath, file.destination);
-    await copy(fullPackagePath, fullOutputPath);
-    logger.success(`${fullPackagePath} copied successfully to ${fullOutputPath}.`);
+    if (!Array.isArray(packageFiles)) {
+      throw new Error(`Package configuration for ${packageName} not found.`);
+    }
+
+    const filesToCopy = packageFiles.map((file) => ({
+      source: path.join(SHARED_BOILERPLATE_DIR, file.source),
+      destination: path.join(outputPath, file.destination),
+    }));
+
+    copyFiles(filesToCopy);
+    logger.success(
+      `All configuration files for ${packageName} copied successfully.`,
+    );
+  } catch (error) {
+    logger.error(
+      `Failed to copy configuration for ${packageName}: ${error.message}`,
+    );
+    throw error; // Propagate the error to be handled by the calling function
   }
 }
 

--- a/packages/ontario-frontend-cli/core/utils/template/configure.js
+++ b/packages/ontario-frontend-cli/core/utils/template/configure.js
@@ -18,9 +18,9 @@ const ontarioCreateAppTemplates = (answers) => [
   { template: 'package.njk', outputDir: '', outputFile: 'package.json' },
   { template: 'README.njk', outputDir: '', outputFile: 'README.md' },
   { template: 'eleventy.njk', outputDir: '', outputFile: '.eleventy.js' },
-  { template: 'en.njk', outputDir: 'src', outputFile: `${answers.enRoot}.njk` },
+  { template: 'en.njk', outputDir: 'src', outputFile: `${answers.enPage}.njk` },
   { template: 'index.njk', outputDir: 'src', outputFile: 'index.njk' },
-  { template: 'fr.njk', outputDir: 'src', outputFile: `${answers.frRoot}.njk` },
+  { template: 'fr.njk', outputDir: 'src', outputFile: `${answers.frPage}.njk` },
   { template: 'sitemap.njk', outputDir: 'src', outputFile: 'sitemap.njk' },
   { template: 'globals.njk', outputDir: 'src/_data', outputFile: 'globals.js' },
 ];

--- a/packages/ontario-frontend-cli/core/utils/template/render.js
+++ b/packages/ontario-frontend-cli/core/utils/template/render.js
@@ -10,9 +10,9 @@ const logger = require('../logger');
  */
 async function renderAndWrite(templatePath, outputPath, context) {
   try {
-    logger.info('Rendering the template');
+    logger.debug('Rendering the template: ', templatePath);
     const content = nunjucks.render(templatePath, context);
-    logger.info('Writing the file');
+    logger.debug('Writing the file: ', outputPath);
     await write(outputPath, content);
   } catch (error) {
     logger.error(`Failed to render and write ${outputPath}: ${error.message}`);

--- a/packages/ontario-frontend-cli/core/validation/validatePackageJson.js
+++ b/packages/ontario-frontend-cli/core/validation/validatePackageJson.js
@@ -1,5 +1,7 @@
 const logger = require('../utils/logger');
 const { readPackageJson } = require('../utils/project/readPackageJson');
+const fs = require('fs').promises;
+const path = require('path');
 
 /**
  * Checks if a package.json file exists in the given directory.

--- a/packages/ontario-frontend-cli/core/validation/validationUtils.js
+++ b/packages/ontario-frontend-cli/core/validation/validationUtils.js
@@ -4,7 +4,7 @@ const isPresent = (value) => value && value.trim() !== '';
 // Checks if the value is entirely lowercase
 const isLowercase = (value) => value === value.toLowerCase();
 
-// Checks if the value is URL-safe (alphanumeric, hyphens, underscores)
+// Checks if the value is URL-safe (alphanumeric, lowercase, hyphens, underscores)
 const isUrlSafe = (value) => /^[a-z0-9_-]+$/.test(value);
 
 // Checks if the value does not start with a dot or underscore

--- a/packages/ontario-frontend-cli/resources/templates/ontario-create-app/eleventy.njk
+++ b/packages/ontario-frontend-cli/resources/templates/ontario-create-app/eleventy.njk
@@ -2,7 +2,7 @@ const toolkit = require('@ongov/ontario-frontend');
 
 function configFunc(eleventyConfig) {
   eleventyConfig.addPassthroughCopy({
-    'src/assets': '{{ enRoot }}/assets',
+    'src/assets': '{{ enPage }}/assets',
   });
 
   eleventyConfig.addLayoutAlias('ontariocaLayout', 'vendor/ontario-ca/layout.njk');

--- a/packages/ontario-frontend-cli/resources/templates/ontario-create-app/en.njk
+++ b/packages/ontario-frontend-cli/resources/templates/ontario-create-app/en.njk
@@ -2,7 +2,7 @@
 layout: ontariocaLayout
 title: "Ontario.ca Frontend"
 description: "The best way to start building applications for Ontario.ca."
-fr_page_url: "/{{ frRoot }}"
+fr_page_url: "/{{ frPage }}"
 date: {{ createDate }}
 published_date: {{ createDate }}
 ---

--- a/packages/ontario-frontend-cli/resources/templates/ontario-create-app/fr.njk
+++ b/packages/ontario-frontend-cli/resources/templates/ontario-create-app/fr.njk
@@ -3,7 +3,7 @@ layout: ontariocaLayout
 title: "Ontario d'Avant"
 description: "La meilleure façon de commencer à créer des applications pour Ontario.ca."
 lang: fr
-en_page_url: "/{{ enRoot }}"
+en_page_url: "/{{ enPage }}"
 date: {{ createDate }}
 published_date: {{ createDate }}
 ---

--- a/packages/ontario-frontend-cli/resources/templates/ontario-create-app/globals.njk
+++ b/packages/ontario-frontend-cli/resources/templates/ontario-create-app/globals.njk
@@ -17,7 +17,7 @@ module.exports = () => {
 
   const footerType = 'default';
 
-  const assetsPath = `/{{enRoot}}/assets`;
+  const assetsPath = `/{{enPage}}/assets`;
 
   // Google Tag Manager can be configured here.  If set, the
   // GOOGLE_TAGMANAGER_ID environment variable will take precedence.

--- a/packages/ontario-frontend-cli/resources/templates/ontario-create-app/index.njk
+++ b/packages/ontario-frontend-cli/resources/templates/ontario-create-app/index.njk
@@ -1,5 +1,5 @@
 ---
-redirect: "/{{ enRoot }}"
+redirect: "/{{ enPage }}"
 eleventyExcludeFromCollections: true
 ---
 {% raw %}

--- a/packages/ontario-frontend-cli/resources/templates/ontario-create-app/sitemap.njk
+++ b/packages/ontario-frontend-cli/resources/templates/ontario-create-app/sitemap.njk
@@ -1,6 +1,6 @@
 ---
 eleventyExcludeFromCollections: true
-permalink: "{{ enRoot }}/sitemap.xml"
+permalink: "{{ enPage }}/sitemap.xml"
 domainUrl: "https://www.ontario.ca"
 ---
 <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
This merge request introduces new CLI parameters, or options, to the `ontario-create-app` project initialization command, allowing users to specify English and French page names directly from the command line. This enhancement bypasses the corresponding interactive questions, speeding up the project initialization process.

## Changes Introduced

-  Added support for --enPage and --frPage options in the CLI tool.
- Users can now specify the English page name using --enPage <enPageName>.
- Users can now specify the French page name using --frPage <frPageName>.

- When the --enPage parameter is used, the interactive question for the English page name is skipped.
- When the --frPage parameter is used, the interactive question for the French page name is skipped.
- If both parameters are provided, both corresponding questions are bypassed.
 
- Validated that the provided page names are alphanumeric and do not contain special characters or spaces. This is handled using the centralized validFileName function.

- Updated handleCreateAppCommand to handle the new parameters and skip the corresponding questions if the parameters are provided.
- Enhanced error handling and logging within the command handler.

---

## Acceptance Criteria

- Users can initialize a new project using the CLI tool with --enPage and/or --frPage parameters.
- The interactive setup bypasses the corresponding questions when the parameters are provided.
- The tool validates the provided page names.
- A confirmation message is displayed after project initialization.
- Relevant information is logged during the project initialization process.
- Clear error messages are provided if invalid parameters are given or if there are issues with setting the page names.

## Example Usage

```sh
create-ontario-app --enPage enhome
```

```sh
create-ontario-app --frPage fraccueil
```

```sh
create-ontario-app --enPage enhome --frPage frpage
```



