### PR TITLE
[ONFRONT-17] bypass config prompts

### DIFF
--- a/packages/ontario-frontend-cli/bin/ontario-create-app.js
+++ b/packages/ontario-frontend-cli/bin/ontario-create-app.js
@@ -70,12 +70,12 @@ const program = new Command();
     .option(
       '--eslint [value]',
       'Include ESLint configuration (true/false)',
-      (value) => (value === 'false' ? false : true),
+      (value) => (value !== 'false'),
     )
     .option(
       '--prettier [value]',
       'Include Prettier configuration (true/false)',
-      (value) => (value === 'false' ? false : true),
+      (value) => (value !== 'false'),
     )
     .option('--debug', 'Enable debug output')
     .option(

--- a/packages/ontario-frontend-cli/bin/ontario-create-app.js
+++ b/packages/ontario-frontend-cli/bin/ontario-create-app.js
@@ -67,8 +67,16 @@ const program = new Command();
         return value;
       },
     )
-    .option('--eslint', 'Include ESLint configuration')
-    .option('--prettier', 'Include Prettier configuration')
+    .option(
+      '--eslint [value]',
+      'Include ESLint configuration (true/false)',
+      (value) => (value === 'false' ? false : true),
+    )
+    .option(
+      '--prettier [value]',
+      'Include Prettier configuration (true/false)',
+      (value) => (value === 'false' ? false : true),
+    )
     .option('--debug', 'Enable debug output')
     .option(
       '--local',

--- a/packages/ontario-frontend-cli/bin/ontario-create-app.js
+++ b/packages/ontario-frontend-cli/bin/ontario-create-app.js
@@ -67,6 +67,8 @@ const program = new Command();
         return value;
       },
     )
+    .option('--eslint', 'Include ESLint configuration')
+    .option('--prettier', 'Include Prettier configuration')
     .option('--debug', 'Enable debug output')
     .option(
       '--local',

--- a/packages/ontario-frontend-cli/commands/ontario-create-app/handleCreateApp.js
+++ b/packages/ontario-frontend-cli/commands/ontario-create-app/handleCreateApp.js
@@ -148,6 +148,8 @@ async function handleCreateAppCommand(cmd = {}) {
       projectName: cmd.projectName || '',
       enPage: cmd.enPage || '',
       frPage: cmd.frPage || '',
+      addESLint: cmd.eslint || false,
+      addPrettier: cmd.prettier || false,
     };
 
     logger.debug('Command options:', options);
@@ -160,6 +162,8 @@ async function handleCreateAppCommand(cmd = {}) {
       askProjectName: !options.projectName,
       askEnPage: !options.enPage,
       askFrPage: !options.frPage,
+      askESLint: !options.addESLint,
+      askPrettier: !options.addPrettier,
     };
 
     const questions = createOntarioAppQuestions(askQuestions);
@@ -174,6 +178,8 @@ async function handleCreateAppCommand(cmd = {}) {
       projectName: options.projectName || answers.projectName,
       enPage: options.enPage || answers.enPage,
       frPage: options.frPage || answers.frPage,
+      addESLint: options.addESLint || answers.addESLint,
+      addPrettier: options.addPrettier || answers.addPrettier,
     };
 
     logger.debug('Final answers:', finalAnswers);

--- a/packages/ontario-frontend-cli/commands/ontario-create-app/handleCreateApp.js
+++ b/packages/ontario-frontend-cli/commands/ontario-create-app/handleCreateApp.js
@@ -166,9 +166,9 @@ async function handleCreateAppCommand(cmd = {}) {
       askProjectName: !options.projectName,
       askEnPage: !options.enPage,
       askFrPage: !options.frPage,
-      // Check if ESLint option was provided; if not, ask the question
+      // Check if ESLint option was provided (true or false); if not, set as undefined to ask the question
       askESLint: options.addESLint === undefined,
-      // Check if Prettier option was provided; if not, ask the question
+      // Check if Prettier option was provided (true or false); if not, set as undefined to ask the question
       askPrettier: options.addPrettier === undefined,
     };
 

--- a/packages/ontario-frontend-cli/commands/ontario-create-app/handleCreateApp.js
+++ b/packages/ontario-frontend-cli/commands/ontario-create-app/handleCreateApp.js
@@ -148,8 +148,10 @@ async function handleCreateAppCommand(cmd = {}) {
       projectName: cmd.projectName || '',
       enPage: cmd.enPage || '',
       frPage: cmd.frPage || '',
-      addESLint: cmd.eslint || false,
-      addPrettier: cmd.prettier || false,
+      // Determine whether to add ESLint based on the command line argument; undefined means the question will be asked
+      addESLint: typeof cmd.eslint === 'boolean' ? cmd.eslint : undefined,
+      // Determine whether to add Prettier based on the command line argument; undefined means the question will be asked
+      addPrettier: typeof cmd.prettier === 'boolean' ? cmd.prettier : undefined,
     };
 
     logger.debug('Command options:', options);
@@ -162,8 +164,8 @@ async function handleCreateAppCommand(cmd = {}) {
       askProjectName: !options.projectName,
       askEnPage: !options.enPage,
       askFrPage: !options.frPage,
-      askESLint: !options.addESLint,
-      askPrettier: !options.addPrettier,
+      askESLint: options.addESLint === undefined,
+      askPrettier: options.addPrettier === undefined,
     };
 
     const questions = createOntarioAppQuestions(askQuestions);
@@ -172,14 +174,14 @@ async function handleCreateAppCommand(cmd = {}) {
 
     logger.debug('User answers:', answers);
 
-    // Merge the answers with the provided projectName, enPage, and frPage if any
+    // Merge the answers with the provided options, giving priority to the options
     const finalAnswers = {
       ...answers,
       projectName: options.projectName || answers.projectName,
       enPage: options.enPage || answers.enPage,
       frPage: options.frPage || answers.frPage,
-      addESLint: options.addESLint || answers.addESLint,
-      addPrettier: options.addPrettier || answers.addPrettier,
+      addESLint: options.addESLint !== undefined ? options.addESLint : answers.addESLint,
+      addPrettier: options.addPrettier !== undefined ? options.addPrettier : answers.addPrettier,
     };
 
     logger.debug('Final answers:', finalAnswers);

--- a/packages/ontario-frontend-cli/commands/ontario-create-app/handleCreateApp.js
+++ b/packages/ontario-frontend-cli/commands/ontario-create-app/handleCreateApp.js
@@ -166,7 +166,9 @@ async function handleCreateAppCommand(cmd = {}) {
       askProjectName: !options.projectName,
       askEnPage: !options.enPage,
       askFrPage: !options.frPage,
+      // Check if ESLint option was provided; if not, ask the question
       askESLint: options.addESLint === undefined,
+      // Check if Prettier option was provided; if not, ask the question
       askPrettier: options.addPrettier === undefined,
     };
 
@@ -182,8 +184,12 @@ async function handleCreateAppCommand(cmd = {}) {
       projectName: options.projectName || answers.projectName,
       enPage: options.enPage || answers.enPage,
       frPage: options.frPage || answers.frPage,
-      addESLint: options.addESLint !== undefined ? options.addESLint : answers.addESLint,
-      addPrettier: options.addPrettier !== undefined ? options.addPrettier : answers.addPrettier,
+      addESLint:
+        options.addESLint !== undefined ? options.addESLint : answers.addESLint,
+      addPrettier:
+        options.addPrettier !== undefined
+          ? options.addPrettier
+          : answers.addPrettier,
     };
 
     logger.debug('Final answers:', finalAnswers);

--- a/packages/ontario-frontend-cli/core/questions/eslintQuestion.js
+++ b/packages/ontario-frontend-cli/core/questions/eslintQuestion.js
@@ -1,12 +1,20 @@
 const { question } = require('../utils/styling/textStyling');
 
+/**
+ * Generates a question object for ESLint configuration.
+ *
+ * @param {boolean} askESLint - Whether to ask for ESLint configuration.
+ * @returns {Object} A question object to be used with inquirer.prompt.
+ */
 const eslintQuestion = (askESLint) => ({
   type: 'list',
   name: 'addESLint',
-  message: question('Add ESLint for fixing code problems?'),
-  choices: ['Yes', 'No'],
-  default: 'No',
-  filter: (value) => value === 'Yes',
+  message: question('Would you like to add ESLint for fixing code problems?'),
+  choices: [
+    { name: 'Yes', value: true },
+    { name: 'No', value: false },
+  ],
+  default: 1, // Default to "No"
   when: askESLint,
 });
 

--- a/packages/ontario-frontend-cli/core/questions/eslintQuestion.js
+++ b/packages/ontario-frontend-cli/core/questions/eslintQuestion.js
@@ -1,12 +1,13 @@
 const { question } = require('../utils/styling/textStyling');
 
-const eslintQuestion = {
+const eslintQuestion = (askESLint) => ({
   type: 'list',
   name: 'addESLint',
   message: question('Add ESLint for fixing code problems?'),
   choices: ['Yes', 'No'],
   default: 'No',
   filter: (value) => value === 'Yes',
-};
+  when: askESLint,
+});
 
 module.exports = eslintQuestion;

--- a/packages/ontario-frontend-cli/core/questions/index.js
+++ b/packages/ontario-frontend-cli/core/questions/index.js
@@ -10,6 +10,8 @@ const prettierQuestion = require('./prettierQuestion');
  * @param {boolean} askQuestions.askProjectName - Whether to ask for the project name.
  * @param {boolean} askQuestions.askEnPage - Whether to ask for the English page name.
  * @param {boolean} askQuestions.askFrPage - Whether to ask for the French page name.
+ * @param {boolean} askQuestions.askESLint - Whether to ask for ESLint configuration.
+ * @param {boolean} askQuestions.askPrettier - Whether to ask for Prettier configuration.
  * @returns {Array<Object>} An array of question objects to be used with inquirer.prompt.
  *
  * The function conditionally includes questions based on the provided `askQuestions` object.
@@ -18,8 +20,8 @@ const prettierQuestion = require('./prettierQuestion');
 const createOntarioAppQuestions = (askQuestions) => [
   projectNameQuestion(askQuestions.askProjectName),
   ...languagePageQuestions(askQuestions.askEnPage, askQuestions.askFrPage),
-  eslintQuestion,
-  prettierQuestion,
+  eslintQuestion(askQuestions.askESLint),
+  prettierQuestion(askQuestions.askPrettier),
 ];
 
 module.exports = {

--- a/packages/ontario-frontend-cli/core/questions/prettierQuestion.js
+++ b/packages/ontario-frontend-cli/core/questions/prettierQuestion.js
@@ -1,12 +1,13 @@
 const { question } = require('../utils/styling/textStyling');
 
-const prettierQuestion = {
+const prettierQuestion = (askPrettier) => ({
   type: 'list',
   name: 'addPrettier',
   message: question('Add Prettier for formatting and styling code?'),
   choices: ['Yes', 'No'],
   default: 'No',
   filter: (value) => value === 'Yes',
-};
+  when: askPrettier,
+});
 
 module.exports = prettierQuestion;

--- a/packages/ontario-frontend-cli/core/questions/prettierQuestion.js
+++ b/packages/ontario-frontend-cli/core/questions/prettierQuestion.js
@@ -1,12 +1,20 @@
 const { question } = require('../utils/styling/textStyling');
 
+/**
+ * Generates a question object for Prettier configuration.
+ *
+ * @param {boolean} askPrettier - Whether to ask for Prettier configuration.
+ * @returns {Object} A question object to be used with inquirer.prompt.
+ */
 const prettierQuestion = (askPrettier) => ({
   type: 'list',
   name: 'addPrettier',
-  message: question('Add Prettier for formatting and styling code?'),
-  choices: ['Yes', 'No'],
-  default: 'No',
-  filter: (value) => value === 'Yes',
+  message: question('Would you like to add Prettier for formatting and styling code?'),
+  choices: [
+    { name: 'Yes', value: true },
+    { name: 'No', value: false },
+  ],
+  default: 1, // Default to "No"
   when: askPrettier,
 });
 


### PR DESCRIPTION
### **PR Description: Bypass Configuration Prompts for ESLint and Prettier**

#### **Summary**
This pull request enhances the Ontario Frontend CLI by adding the capability to bypass configuration prompts for ESLint and Prettier. Users can specify these configurations directly via command-line options, expediting the project setup process.

#### **Changes Made**

1. **Command-Line Options:**
   - Added `--eslint` and `--prettier` options.

2. **Handling Command Options:**
   - Updated `handleCreateAppCommand` to process these options.

3. **Conditional Question Logic:**
   - Modified question objects to conditionally include ESLint and Prettier prompts.

4. **Integration in Question Index:**
   - Updated the index to conditionally include ESLint and Prettier questions.

#### **Detailed Changes**
- **Commits:**
  - **b62c2c4:** Added command-line options for ESLint and Prettier.
  - **4b10e55:** Updated create command with ESLint and Prettier options.
  - **f383dab:** Handled ESLint and Prettier options in create command.
  - **755ba89:** Allowed ESLint and Prettier options to accept true/false values.
  - **1d99225:** Bypassed ESLint and Prettier prompts when options are provided.
  - **4bffe5f:** Merged changes from the develop branch.
  - **9657658:** Refactored logic for handling ESLint and Prettier options.

#### **Acceptance Criteria**
- **CLI Initialization with Parameters:** 
  - Users can initialize a new project with `--eslint` and/or `--prettier` options.
- **Parameter Recognition:**
  - The CLI tool recognizes `--eslint` and `--prettier` parameters, skipping corresponding configuration prompts.
- **Combining Parameters:**
  - Users can combine both parameters (`--eslint --prettier`) without being prompted for configurations.
- **Default Behavior:**
  - If no parameters are provided, the CLI proceeds with the interactive setup.
- **Consistent Initialization:**
  - Ensures all necessary configurations and dependencies are set up.
- **Confirmation Message:**
  - Displays a confirmation message indicating the inclusion of ESLint and/or Prettier.
- **Logging and Notifications:**
  - Logs relevant information about selected code quality packages and configurations.
- **Error Handling:**
  - Provides clear error messages and guidance if invalid parameters are provided or if there are issues with setting up ESLint and/or Prettier.

#### **Example Usage**

1. **Using ESLint:**
   ```sh
   npx @ongov/ontario-frontend create-ontario-app --eslint
   ```
   and
   ```sh
   npx @ongov/ontario-frontend create-ontario-app --eslint true
   ```

2. **Using Prettier:**
   ```sh
   npx @ongov/ontario-frontend create-ontario-app --prettier
   ```
   and
   ```sh
   npx @ongov/ontario-frontend create-ontario-app --prettier true
   ```

3. **Using Both ESLint and Prettier:**
   ```sh
   npx @ongov/ontario-frontend create-ontario-app --eslint --prettier
   ```
   and
   ```sh
   npx @ongov/ontario-frontend create-ontario-app --eslint true --prettier true
   ```
   and
   ```sh
   npx @ongov/ontario-frontend create-ontario-app --eslint --prettier true
   ```
   and
   ```sh
   npx @ongov/ontario-frontend create-ontario-app --eslint true --prettier
   ```

4. **NOT using ESLint:**
   ```sh
   npx @ongov/ontario-frontend create-ontario-app --eslint false
   ```

5. **NOT using Prettier:**
   ```sh
   npx @ongov/ontario-frontend create-ontario-app --prettier false
   ```

6. **Using NEITHER ESLint and Prettier:**
   ```sh
   npx @ongov/ontario-frontend create-ontario-app --eslint false --prettier false
   ```

7. **Using ESLint but not Prettier:**
   ```sh
   npx @ongov/ontario-frontend create-ontario-app --eslint --prettier false
   ```

8. **Using Prettier but not ESLint:**
   ```sh
   npx @ongov/ontario-frontend create-ontario-app --eslint false --prettier true
   ```

#### **Related Issues**
- Resolves issue ONFRONT-17: Bypass configuration prompts for ESLint and Prettier.